### PR TITLE
Make GitHub names clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The initial stakeholders consists of:
 * Tanner Nelson ([@tannernelson](https://github.com/tannernelson), Vapor)
 * Tom Doron ([@tomerd](https://github.com/tomerd), Apple)
 * Daniel Dunbar ([@ddunbar](https://github.com/ddunbar), Apple)
+* Dan Appel ([@danappelxx](https://github.com/danappelxx), Zewo)
 
 ### Additional Information
 More information can be found in the [Server APIs pages](http://swift.org/server-apis/) of [swift.org](http://swift.org), or by posting to the [swift-server-dev](https://lists.swift.org/mailman/listinfo/swift-server-dev) mailing list.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Analagous to the primary Core Team for Swift, the work group has a steering team
 
 The initial steering team consists of:
 
-* Chris Bailey (@seabaylea, IBM Kitura)
-* Logan Wright (@LoganWright, Vapor)
-* Paulo Faria  (@paulofaria, Zewo)
-* Steve Algernon (@salgernon, Apple)
+* Chris Bailey ([@seabaylea](https://github.com/seabaylea), IBM Kitura)
+* Logan Wright ([@LoganWright](https://github.com/LoganWright), Vapor)
+* Paulo Faria  ([@paulofaria](https://github.com/paulofaria), Zewo)
+* Steve Algernon ([@salgernon](https://github.com/salgernon), Apple)
 
 ### <a name="stakeholders"></a>Stakeholders
 The work group also has stakeholders who represent server-side frameworks or applications. They are responsible for providing early input on use cases and API design as part of the iterative design and implementation process, and to adopt the new APIs into their frameworks.
@@ -32,13 +32,12 @@ Joining and leaving the work group as a stakeholder is a straightforward process
 
 The initial stakeholders consists of:
 
-* Gregor Milos (@gmilos, Apple)
-* Kyle Jessup (@kjessup, Perfect)
-* Robert Dickerson (@rfdickerson, IBM Kitura)
-* Tanner Nelson (@tannernelson, Vapor)
-* Tom Doron (@tomerd, Apple)
-* Daniel Dunbar (@ddunbar, Apple)
-* Dan Appel (@danappelxx, Zewo)
+* Gregor Milos ([@gmilos](https://github.com/gmilos), Apple)
+* Kyle Jessup ([@kjessup](https://github.com/kjessup), Perfect)
+* Robert Dickerson ([@rfdickerson](https://github.com/rfdickerson), IBM Kitura)
+* Tanner Nelson ([@tannernelson](https://github.com/tannernelson), Vapor)
+* Tom Doron ([@tomerd](https://github.com/tomerd), Apple)
+* Daniel Dunbar ([@ddunbar](https://github.com/ddunbar), Apple)
 
 ### Additional Information
 More information can be found in the [Server APIs pages](http://swift.org/server-apis/) of [swift.org](http://swift.org), or by posting to the [swift-server-dev](https://lists.swift.org/mailman/listinfo/swift-server-dev) mailing list.


### PR DESCRIPTION
... so they redirect to the person's GitHub profile page.
